### PR TITLE
Fix 8.17 download links in opam file

### DIFF
--- a/opam/opam-repository/packages/coq-core/coq-core.8.17.0/opam
+++ b/opam/opam-repository/packages/coq-core/coq-core.8.17.0/opam
@@ -64,7 +64,7 @@ dev-repo: "git+https://github.com/coq/coq.git"
 depopts: ["coq-native"]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.0.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.17.0/coq-8.17.0.tar.gz"
   checksum: "sha512=2f77bcb5211018b5d46320fd39fd34450eeb654aca44551b28bb50a2364398c4b34587630b6558db867ecfb63b246fd3e29dc2375f99967ff62bc002db9c3250"
 }
 extra-files: [

--- a/opam/opam-repository/packages/coq-core/coq-core.8.17.1/opam
+++ b/opam/opam-repository/packages/coq-core/coq-core.8.17.1/opam
@@ -65,7 +65,7 @@ dev-repo: "git+https://github.com/coq/coq.git"
 depopts: ["coq-native"]
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.17.1/coq-8.17.1.tar.gz"
   checksum: "sha512=9a35311acec2a806730b94ac7dceabc88837f235c52a14c026827d9b89433bd7fa9555a9fc6829aa49edfedb24c8bbaf1411ebf463b74a50aeb17cba47745b6b"
 }
 extra-files: [

--- a/opam/opam-repository/packages/coqide/coqide.8.17.1/opam
+++ b/opam/opam-repository/packages/coqide/coqide.8.17.1/opam
@@ -40,7 +40,7 @@ build: [
 dev-repo: "git+https://github.com/coq/coq.git"
 
 url {
-  src: "https://github.com/coq/coq/archive/refs/tags/V8.17.1.tar.gz"
+  src: "https://github.com/coq/coq/releases/download/V8.17.1/coq-8.17.1.tar.gz"
   checksum: "sha512=9a35311acec2a806730b94ac7dceabc88837f235c52a14c026827d9b89433bd7fa9555a9fc6829aa49edfedb24c8bbaf1411ebf463b74a50aeb17cba47745b6b"
 }
 extra-files: [


### PR DESCRIPTION
The download links for some packages for versions 8.17 were incorrect, as in, the checksum did not correspond. This should fix them (links copied from the upstream opam ocaml repository, checksums checked by hand, but may want to double check of course).