### PR TITLE
Only copy files if they exist

### DIFF
--- a/windows/Coq.nsi
+++ b/windows/Coq.nsi
@@ -411,7 +411,8 @@ FunctionEnd
 ; if sections exist (by !ifdef <section_index_var>) to decide if the license page must be included.
 ; The section index variables are only defined after the section definitions.
 
-  !define MUI_ICON "coq.ico"
+  !system "if exist coq.ico (echo !define MUI_ICON \"coq.ico\") else (echo !define MUI_ICON \"coq-shell.ico\")"
+
   ;!define MUI_CUSTOMFUNCTION_GUIINIT PreselectSections
 
   !insertmacro MUI_PAGE_WELCOME

--- a/windows/create_installer_windows.sh
+++ b/windows/create_installer_windows.sh
@@ -468,10 +468,19 @@ fi
 
 # Copy some files from source
 cp source/coq/LICENSE .
-cp source/coqide/ide/coqide/coq.ico .
 mkdir -p files/bin
-cp source/coqide/ide/coqide/coq.ico files/bin/
-cp source/coq-compcert/LICENSE coq-compcert-license.txt
+if opam list --installed --silent coqide
+then
+  cp source/coqide/ide/coqide/coq.ico .
+  cp source/coqide/ide/coqide/coq.ico files/bin/
+else
+  cp /platform/windows/coq-shell.ico .
+  cp /platform/windows/coq-shell.ico files/bin/coq.ico
+fi
+if opam list --installed --silent coq-compcert
+then
+  cp source/coq-compcert/LICENSE coq-compcert-license.txt
+fi
 if [ -n "$NSIS_VST_CHECK" ]
 then
   cp source/$vst_pkg/LICENSE coq-vst-license.txt

--- a/windows/create_installer_windows.sh
+++ b/windows/create_installer_windows.sh
@@ -475,7 +475,6 @@ then
   cp source/coqide/ide/coqide/coq.ico files/bin/
 else
   cp /platform/windows/coq-shell.ico .
-  cp /platform/windows/coq-shell.ico files/bin/coq.ico
 fi
 if opam list --installed --silent coq-compcert
 then


### PR DESCRIPTION
So far, the Windows installer failed when either Coqide was not installed or when compcert was not installed. This PR aims to fix that.