### PR TITLE
chore(opam): temporary vendor of coq-mathcomp-algebra-tactics.1.2.7

### DIFF
--- a/opam/opam-coq-archive/released/packages/coq-mathcomp-algebra-tactics/ccoq-mathcomp-algebra-tactics.1.2.7/opam
+++ b/opam/opam-coq-archive/released/packages/coq-mathcomp-algebra-tactics/ccoq-mathcomp-algebra-tactics.1.2.7/opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+maintainer: "kazuhiko.sakaguchi@inria.fr"
+
+homepage: "https://github.com/math-comp/algebra-tactics"
+dev-repo: "git+https://github.com/math-comp/algebra-tactics.git"
+bug-reports: "https://github.com/math-comp/algebra-tactics/issues"
+license: "CECILL-B"
+
+synopsis: "Ring, field, lra, nra, and psatz tactics for Mathematical Components"
+description: """
+This library provides `ring`, `field`, `lra`, `nra`, and `psatz` tactics for
+the Mathematical Components library. These tactics use the algebraic
+structures defined in the MathComp library and their canonical instances for
+the instance resolution, and do not require any special instance declaration,
+like the `Add Ring` and `Add Field` commands. Therefore, each of these tactics
+works with any instance of the respective structure, including concrete
+instances declared through Hierarchy Builder, abstract instances, and mixed
+concrete and abstract instances, e.g., `int * R` where `R` is an abstract
+commutative ring. Another key feature of Algebra Tactics is that they
+automatically push down ring morphisms and additive functions to leaves of
+ring/field expressions before applying the proof procedures."""
+
+build: [make "-j%{jobs}%" "build"]
+run-test: [make "-j%{jobs}%" "test-suite"]
+install: [make "install"]
+depends: [
+  ("coq" {>= "8.20" & < "9~"} & "coq-elpi" {>= "2.2.0" & < "3~"}
+  | "coq-core" {>= "9.0" & < "9.2~"} & "coq-stdlib" & "coq-elpi" {>= "2.2.0"})
+  "coq-mathcomp-ssreflect" {>= "2.4" & < "2.5~" | = "dev"}
+  "coq-mathcomp-algebra"
+  "coq-mathcomp-zify" {>= "1.5.0"}
+]
+
+tags: [
+  "logpath:mathcomp.algebra_tactics"
+]
+authors: [
+  "Kazuhiko Sakaguchi"
+  "Pierre Roux"
+]
+url {
+  src: "https://github.com/math-comp/algebra-tactics/archive/refs/tags/1.2.7.tar.gz"
+  checksum: "sha512=1ca3f967123327b9e49ee6f49acfb0e5be8bd85e990df5f5ec9f7934dddab9f77c014f7f3bedc1387f0dde523a47b5c4df9f437a64138fc6031e45c70090eed7"
+}

--- a/package_picks/package-pick-9.0+preview~2025.08.sh
+++ b/package_picks/package-pick-9.0+preview~2025.08.sh
@@ -147,7 +147,7 @@ then
   
   # General mathematics (which requires one of the above tools)
   PACKAGES="${PACKAGES} coq-mathcomp-analysis.1.12.0"
-  PACKAGES="${PACKAGES} coq-mathcomp-algebra-tactics.1.2.6" # Pierre roux recommends to test 1.2.6
+  PACKAGES="${PACKAGES} coq-mathcomp-algebra-tactics.1.2.7"
   #PACKAGES="${PACKAGES} coq-relation-algebra.1.7.11" #  depends coq-aac-tactics
 
   # Formal languages, compilers and code verification


### PR DESCRIPTION
- Adds compatibility with rocq-elpi 3.1.0
- Unblocks Rocq 9.0 CI (nightly failure)
- To be removed once merged and mirrored in opam-repository